### PR TITLE
コラムページの更新、記事フォーマットの統一、ヘッダーリンクの修正

### DIFF
--- a/_header.html
+++ b/_header.html
@@ -2,7 +2,7 @@
     <header class="bg-white shadow-md sticky top-0 z-50">
         <div class="container mx-auto px-6 py-4 flex justify-between items-center">
             <h1 class="text-xl font-bold text-gray-900">
-                <a href="./index.html">AIライター協会</a>
+                <a href="https://a-i-l-a.jp/">AIライター協会</a>
             </h1>
             <nav class="hidden md:flex items-center space-x-8 font-bold">
                 <a href="./about.html" class="text-gray-600 hover:text-blue-800 transition duration-300">協会について</a>


### PR DESCRIPTION
ユーザーの依頼に基づき、以下の3点を修正しました。

1.  `column.html` から不要なコラム記事へのリンクを削除しました。
2.  記事 `articles/ai-vs-human-writers-future.html` のフォーマット（ヘッダー、フッター、見出し、スタイル）を他の記事と統一しました。
3.  ヘッダーのロゴリンクを `https://a-i-l-a.jp/` の絶対パスに変更しました。