### PR TITLE
コラムページの更新、記事フォーマットの統一、ヘッダーリンク修正、新着コラムの動的表示

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -81,4 +81,54 @@ document.addEventListener('DOMContentLoaded', function() {
                 faqContainer.innerHTML = '<p>FAQの読み込みに失敗しました。</p>';
             });
     }
+
+    const loadNewColumns = () => {
+        const container = document.getElementById('new-columns-container');
+        if (!container) {
+            return;
+        }
+
+        fetch('./column.html')
+            .then(response => {
+                if (!response.ok) throw new Error('Failed to load column.html');
+                return response.text();
+            })
+            .then(html => {
+                const parser = new DOMParser();
+                const doc = parser.parseFromString(html, 'text/html');
+                const articles = doc.querySelectorAll('.grid .bg-white.rounded-lg.shadow-lg.overflow-hidden');
+                let columnsHtml = '';
+                articles.forEach((article, index) => {
+                    if (index >= 3) {
+                        return;
+                    }
+
+                    const tempArticle = article.cloneNode(true);
+                    const link = tempArticle.querySelector('a');
+
+                    if (link) {
+                        const href = link.getAttribute('href');
+                        if (href) {
+                            link.setAttribute('href', `./${href}`);
+                        }
+
+                        const img = link.querySelector('img');
+                        if (img) {
+                            const src = img.getAttribute('src');
+                            if (src && !src.startsWith('http') && !src.startsWith('/')) {
+                                img.setAttribute('src', `./${src}`);
+                            }
+                        }
+                    }
+                    columnsHtml += tempArticle.outerHTML;
+                });
+                container.innerHTML = columnsHtml;
+            })
+            .catch(error => {
+                console.error('Error loading new columns:', error);
+                container.innerHTML = '<p>新着コラムの読み込みに失敗しました。</p>';
+            });
+    };
+
+    loadNewColumns();
 });

--- a/index.html
+++ b/index.html
@@ -96,38 +96,7 @@
         <section class="py-20 bg-gray-100">
             <div class="container mx-auto px-6">
                 <h3 class="text-3xl font-bold text-center mb-12">新着コラム</h3>
-                <div class="grid md:grid-cols-3 gap-8">
-                    <!-- コラム記事 1 -->
-                    <div class="bg-white rounded-lg shadow-lg overflow-hidden">
-                        <a href="./articles/ai_writer_coexistence_strategy.html" class="block group">
-                            <img src="./assets/images/coexistence_strategy.jpeg" alt="AIと人間が共存するイメージ" class="w-full h-48 object-cover group-hover:opacity-80 transition-opacity">
-                            <div class="p-6">
-                                <h4 class="font-bold text-lg mb-2 group-hover:text-blue-800">AIはライターの仕事を奪うのか？脅威を「最高の武器」に変える新時代の共存戦略</h4>
-                                <p class="text-gray-600 text-sm leading-relaxed">「AIはライターの仕事を奪う」。この衝撃的な言葉が、メディアで頻繁に取り上げられるようになりました。文章を生成するAIの進化は目覚ましく、その能力に脅威を感じている方も少なくないでしょう。</p>
-                            </div>
-                        </a>
-                    </div>
-                    <!-- コラム記事 2 -->
-                    <div class="bg-white rounded-lg shadow-lg overflow-hidden">
-                        <a href="./articles/ai_rewrites_corporate_education.html" class="block group">
-                            <img src="./assets/images/corporate_education.jpeg" alt="企業研修のイメージ" class="w-full h-48 object-cover group-hover:opacity-80 transition-opacity">
-                            <div class="p-6">
-                                <h4 class="font-bold text-lg mb-2 group-hover:text-blue-800">「文章力は個人の才能」という幻想が組織を壊す。AI時代の新人教育、その驚くべき効果とは？</h4>
-                                <p class="text-gray-600 text-sm leading-relaxed">「あの人の書く文章は分かりやすい」「彼の提案書はいつも説得力がある」。私たちは、優れた文章力を個人の才能やセンスの問題として片付けてしまいがちです。しかし、その認識が、組織全体の成長を阻害し、静かに競争力を蝕んでいるとしたら、どうでしょうか。</p>
-                            </div>
-                        </a>
-                    </div>
-                    <!-- コラム記事 3 -->
-                    <div class="bg-white rounded-lg shadow-lg overflow-hidden">
-                        <a href="./articles/human_strengths_for_ai_era_writers.html" class="block group">
-                            <img src="./assets/images/human_strengths.jpeg" alt="AI時代を生き抜くライターの条件" class="w-full h-48 object-cover group-hover:opacity-80 transition-opacity">
-                            <div class="p-6">
-                                <h4 class="font-bold text-lg mb-2 group-hover:text-blue-800">AI時代を生き抜くライターの条件：機械には真似できない「人間ならでは」の5つの強みとは？</h4>
-                                <p class="text-gray-600 text-sm leading-relaxed">生成AIの進化が、文章を作成する現場を根底から変えようとしています。ボタン一つで流暢な文章が生成される様子を目の当たりにし、「ライターという仕事はAIに奪われるのではないか」という不安を抱いている方も少なくないでしょう。</p>
-                            </div>
-                        </a>
-                    </div>
-                </div>
+                <div id="new-columns-container" class="grid md:grid-cols-3 gap-8"></div>
                 <div class="text-center mt-12">
                     <a href="./column.html" class="inline-block bg-blue-800 text-white px-10 py-3 rounded-md hover:bg-blue-900 transition duration-300 font-bold">コラム一覧へ</a>
                 </div>


### PR DESCRIPTION
ユーザーの依頼に基づき、以下の4点を修正しました。

1.  `column.html` から不要なコラム記事へのリンクを削除しました。
2.  記事 `articles/ai-vs-human-writers-future.html` のフォーマット（ヘッダー、フッター、見出し、スタイル）を他の記事と統一しました。
3.  ヘッダーのロゴリンクを `https://a-i-l-a.jp/` の絶対パスに変更しました。
4.  `index.html` の「新着コラム」が `column.html` の内容を元に自動的に更新されるように、JavaScriptによる動的読み込み機能を追加しました。