### PR TITLE
Fix image on Oki Chinatsu's member page

### DIFF
--- a/members/oki-chinatsu.html
+++ b/members/oki-chinatsu.html
@@ -40,7 +40,7 @@
             <div class="container mx-auto px-6">
                 <div class="flex flex-col md:flex-row items-center gap-12">
                     <div class="md:w-1/3 text-center profile-image-container">
-                        <img src="../assets/images/representative-director.png" alt="大木 千夏" class="rounded-full shadow-xl mx-auto">
+                        <img src="../assets/images/oki-chinatsu.jpeg" alt="大木 千夏" class="rounded-full shadow-xl mx-auto">
                         <h4 class="mt-6 text-xl font-bold">大木 千夏</h4>
                         <p class="text-gray-600">会員</p>
                     </div>


### PR DESCRIPTION
The member page for Oki Chinatsu was incorrectly displaying a generic "representative director" image.

This change updates the `src` attribute of the `img` tag in `members/oki-chinatsu.html` to point to the correct image file, `assets/images/oki-chinatsu.jpeg`.