### PR TITLE
Fix image and positioning for Oki Chinatsu

### DIFF
--- a/members.html
+++ b/members.html
@@ -47,7 +47,7 @@
                     </div>
                     <div class="bg-white rounded-lg shadow-lg overflow-hidden">
                         <a href="./members/oki-chinatsu.html" class="block group">
-                            <img src="./assets/images/representative-director.png" alt="大木 千夏" class="w-full h-48 object-cover group-hover:opacity-80 transition-opacity">
+                            <img src="./assets/images/oki-chinatsu.jpeg" alt="大木 千夏" class="w-full h-48 object-cover group-hover:opacity-80 transition-opacity" style="object-position: top;">
                             <div class="p-6">
                                 <h4 class="font-bold text-lg mb-2 group-hover:text-blue-800">大木 千夏</h4>
                                 <p class="text-gray-600 text-sm leading-relaxed">会員</p>


### PR DESCRIPTION
This commit addresses two issues related to Oki Chinatsu's image:

1.  On her individual member page (`members/oki-chinatsu.html`), the image was pointing to a generic placeholder. It has been updated to use her specific photo (`oki-chinatsu.jpeg`).

2.  On the main members list page (`members.html`), the image was also incorrect. This has been fixed. Additionally, the image was not positioned correctly, causing her face to be cut off. An inline style (`object-position: top;`) has been added to correct the vertical alignment of the image.