### PR TITLE
feat: Add portfolio link to Oki Chinatsu's page

### DIFF
--- a/members/oki-chinatsu.html
+++ b/members/oki-chinatsu.html
@@ -49,6 +49,13 @@
                         <p class="mb-4 leading-relaxed">
                             臨床検査技師として総合病院や大学発ベンチャーで経験を積んだ後、2021年にライターとして独立。医療・看護分野を中心に執筆する中で金融にも関心を持ち、2級FP技能士・AFPを取得。現在は独立系FP・金融ライターとしても活動中。
                         </p>
+
+                        <h3 class="text-3xl font-bold mb-4 mt-8">ポートフォリオ</h3>
+                        <div>
+                            <a href="https://note.com/mosako_wr/n/n16045bd39b64" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline">
+                                noteで実績を見る
+                            </a>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This change adds a new "Portfolio" section to the member page for Oki Chinatsu. This section contains a link to her note.com page, which serves as her portfolio, as requested by the user.