### PR TITLE
水間雄紀のプロフィール画像を更新

### DIFF
--- a/members/mizuma-yuki.html
+++ b/members/mizuma-yuki.html
@@ -40,7 +40,7 @@
             <div class="container mx-auto px-6">
                 <div class="flex flex-col md:flex-row items-center gap-12">
                     <div class="md:w-1/3 text-center profile-image-container">
-                        <img src="../assets/images/representative-director.png" alt="代表理事 水間雄紀の写真" class="rounded-full shadow-xl mx-auto">
+                        <img src="../assets/images/mizuma-yuki.png" alt="代表理事 水間雄紀の写真" class="rounded-full shadow-xl mx-auto">
                         <h4 class="mt-6 text-xl font-bold">水間 雄紀</h4>
                         <p class="text-gray-600">代表理事</p>
                     </div>


### PR DESCRIPTION
水間雄紀のプロフィール画像を、新しい画像 `mizuma-yuki.png` に差し替えました。