### PR TITLE
feat: Add OGP and Favicon to all pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -5,6 +5,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>協会について - AIライター協会</title>
     <meta name="description" content="AIライター協会の公式ページです。当協会の設立趣旨、理念、代表挨拶、そして協会概要について詳しくご紹介します。AI時代の新しいライターの価値を定義し、信頼されるライターを育成します。">
+
+    <!-- OGP -->
+    <meta property="og:url" content="https://a-i-l-a.jp/about.html">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="協会について - AIライター協会">
+    <meta property="og:description" content="AIライター協会の公式ページです。当協会の設立趣旨、理念、代表挨拶、そして協会概要について詳しくご紹介します。AI時代の新しいライターの価値を定義し、信頼されるライターを育成します。">
+    <meta property="og:site_name" content="AIライター協会">
+    <meta property="og:image" content="https://a-i-l-a.jp/assets/images/our-mission.png">
+    <meta name="twitter:card" content="summary_large_image">
+
+    <!-- Favicon -->
+    <link rel="icon" href="/assets/images/logo.png" type="image/png">
+    <link rel="apple-touch-icon" href="/assets/images/logo.png">
     
     <!-- Tailwind CSSを読み込み -->
     <script src="https://cdn.tailwindcss.com"></script>

--- a/ai-writer-kentei.html
+++ b/ai-writer-kentei.html
@@ -4,6 +4,20 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AIライター検定 | AIライター協会</title>
+    <meta name="description" content="AI時代に必要な「整える力」を客観的に評価・認定する、日本初のAIライティング検定制度です。AIが生成した文章を、より伝わるコンテンツへと昇華させるスキルを、ここで証明しませんか。">
+
+    <!-- OGP -->
+    <meta property="og:url" content="https://a-i-l-a.jp/ai-writer-kentei.html">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="AIライター検定 | AIライター協会">
+    <meta property="og:description" content="AI時代に必要な「整える力」を客観的に評価・認定する、日本初のAIライティング検定制度です。AIが生成した文章を、より伝わるコンテンツへと昇華させるスキルを、ここで証明しませんか。">
+    <meta property="og:site_name" content="AIライター協会">
+    <meta property="og:image" content="https://a-i-l-a.jp/assets/images/skill-certification.png">
+    <meta name="twitter:card" content="summary_large_image">
+
+    <!-- Favicon -->
+    <link rel="icon" href="/assets/images/logo.png" type="image/png">
+    <link rel="apple-touch-icon" href="/assets/images/logo.png">
     
     <!-- Tailwind CSSを読み込み -->
     <script src="https://cdn.tailwindcss.com"></script>

--- a/article_templete.html
+++ b/article_templete.html
@@ -4,6 +4,20 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AIは「壁打ち相手」として最強のツールである - AIライター協会</title>
+    <meta name="description" content="">
+
+    <!-- OGP -->
+    <meta property="og:url" content="OG_URL_PLACEHOLDER">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="AIは「壁打ち相手」として最強のツールである - AIライター協会">
+    <meta property="og:description" content="">
+    <meta property="og:site_name" content="AIライター協会">
+    <meta property="og:image" content="OG_IMAGE_PLACEHOLDER">
+    <meta name="twitter:card" content="summary_large_image">
+
+    <!-- Favicon -->
+    <link rel="icon" href="../assets/images/logo.png" type="image/png">
+    <link rel="apple-touch-icon" href="../assets/images/logo.png">
     
     <!-- Tailwind CSSを読み込み -->
     <script src="https://cdn.tailwindcss.com"></script>

--- a/column.html
+++ b/column.html
@@ -4,6 +4,20 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>コラム - AIライター協会</title>
+    <meta name="description" content="AIライティングに関する最新情報、技術解説、ライターのキャリア戦略など、AIと共存するための有益なコラムを掲載しています。">
+
+    <!-- OGP -->
+    <meta property="og:url" content="https://a-i-l-a.jp/column.html">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="コラム - AIライター協会">
+    <meta property="og:description" content="AIライティングに関する最新情報、技術解説、ライターのキャリア戦略など、AIと共存するための有益なコラムを掲載しています。">
+    <meta property="og:site_name" content="AIライター協会">
+    <meta property="og:image" content="https://a-i-l-a.jp/assets/images/logo.png">
+    <meta name="twitter:card" content="summary_large_image">
+
+    <!-- Favicon -->
+    <link rel="icon" href="/assets/images/logo.png" type="image/png">
+    <link rel="apple-touch-icon" href="/assets/images/logo.png">
     
     <!-- Tailwind CSSを読み込み -->
     <script src="https://cdn.tailwindcss.com"></script>

--- a/contact.html
+++ b/contact.html
@@ -5,6 +5,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>お問い合わせ - AIライター協会</title>
     <meta name="description" content="AIライター協会へのお問い合わせページです。入会案内、AIライター検定、その他サービスに関するご質問はこちらのフォームからお気軽にご連絡ください。">
+
+    <!-- OGP -->
+    <meta property="og:url" content="https://a-i-l-a.jp/contact.html">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="お問い合わせ - AIライター協会">
+    <meta property="og:description" content="AIライター協会へのお問い合わせページです。入会案内、AIライター検定、その他サービスに関するご質問はこちらのフォームからお気軽にご連絡ください。">
+    <meta property="og:site_name" content="AIライター協会">
+    <meta property="og:image" content="https://a-i-l-a.jp/assets/images/logo.png">
+    <meta name="twitter:card" content="summary_large_image">
+
+    <!-- Favicon -->
+    <link rel="icon" href="/assets/images/logo.png" type="image/png">
+    <link rel="apple-touch-icon" href="/assets/images/logo.png">
     
     <!-- Tailwind CSSを読み込み -->
     <script src="https://cdn.tailwindcss.com"></script>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AIライター協会 - AIと共創する言葉の未来</title>
     <meta name="description" content="一般社団法人AIライター協会は、AIライティング技術の健全な発展と、書き手の価値向上を目指す団体です。AIライター検定やコラム、会員制度を通じて、AI時代の新しいライティングスキルを提供します。">
+
+    <!-- OGP -->
+    <meta property="og:url" content="https://a-i-l-a.jp/">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="AIライター協会 - AIと共創する言葉の未来">
+    <meta property="og:description" content="一般社団法人AIライター協会は、AIライティング技術の健全な発展と、書き手の価値向上を目指す団体です。AIライター検定やコラム、会員制度を通じて、AI時代の新しいライティングスキルを提供します。">
+    <meta property="og:site_name" content="AIライター協会">
+    <meta property="og:image" content="https://a-i-l-a.jp/assets/images/top-image.jpg">
+    <meta name="twitter:card" content="summary_large_image">
+
+    <!-- Favicon -->
+    <link rel="icon" href="/assets/images/logo.png" type="image/png">
+    <link rel="apple-touch-icon" href="/assets/images/logo.png">
     
     <!-- Tailwind CSSを読み込み -->
     <script src="https://cdn.tailwindcss.com"></script>

--- a/members.html
+++ b/members.html
@@ -4,6 +4,20 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>会員一覧 - AIライター協会</title>
+    <meta name="description" content="AIライター協会の認定会員一覧です。AI時代をリードするプロフェッショナルなライターたちをご紹介します。">
+
+    <!-- OGP -->
+    <meta property="og:url" content="https://a-i-l-a.jp/members.html">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="会員一覧 - AIライター協会">
+    <meta property="og:description" content="AIライター協会の認定会員一覧です。AI時代をリードするプロフェッショナルなライターたちをご紹介します。">
+    <meta property="og:site_name" content="AIライター協会">
+    <meta property="og:image" content="https://a-i-l-a.jp/assets/images/logo.png">
+    <meta name="twitter:card" content="summary_large_image">
+
+    <!-- Favicon -->
+    <link rel="icon" href="/assets/images/logo.png" type="image/png">
+    <link rel="apple-touch-icon" href="/assets/images/logo.png">
     
     <!-- Tailwind CSSを読み込み -->
     <script src="https://cdn.tailwindcss.com"></script>

--- a/members/hanayama-sakura.html
+++ b/members/hanayama-sakura.html
@@ -4,6 +4,20 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>花山さくら - AIライター協会</title>
+    <meta name="description" content="Webコンテンツの作成・運用などあらゆるご相談に応じます！Webコンテンツ作成のほかSNS運用代行、メルマガ配信、オウンドメディアやオンラインサロン運営、プロデュースなど実践的なマーケティング経験・知識を基にお客様のご要望に応じたコンテンツをご提供いたします。">
+
+    <!-- OGP -->
+    <meta property="og:url" content="https://a-i-l-a.jp/members/hanayama-sakura.html">
+    <meta property="og:type" content="profile">
+    <meta property="og:title" content="花山さくら - AIライター協会">
+    <meta property="og:description" content="Webコンテンツの作成・運用などあらゆるご相談に応じます！Webコンテンツ作成のほかSNS運用代行、メルマガ配信、オウンドメディアやオンラインサロン運営、プロデュースなど実践的なマーケティング経験・知識を基にお客様のご要望に応じたコンテンツをご提供いたします。">
+    <meta property="og:site_name" content="AIライター協会">
+    <meta property="og:image" content="https://a-i-l-a.jp/assets/images/representative-director.png">
+    <meta name="twitter:card" content="summary_large_image">
+
+    <!-- Favicon -->
+    <link rel="icon" href="../assets/images/logo.png" type="image/png">
+    <link rel="apple-touch-icon" href="../assets/images/logo.png">
 
     <!-- Tailwind CSSを読み込み -->
     <script src="https://cdn.tailwindcss.com"></script>

--- a/members/kanna-tomomi.html
+++ b/members/kanna-tomomi.html
@@ -4,6 +4,20 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>かんな ともみ - AIライター協会</title>
+    <meta name="description" content="病院・福祉施設での相談支援業務に10年以上携わってきた経験があります。クライアントの価値観を尊重しながら、病気や障害、介護やお金のことなど、その方が抱える生活の問題を解決することに尽力してきました。">
+
+    <!-- OGP -->
+    <meta property="og:url" content="https://a-i-l-a.jp/members/kanna-tomomi.html">
+    <meta property="og:type" content="profile">
+    <meta property="og:title" content="かんな ともみ - AIライター協会">
+    <meta property="og:description" content="病院・福祉施設での相談支援業務に10年以上携わってきた経験があります。クライアントの価値観を尊重しながら、病気や障害、介護やお金のことなど、その方が抱える生活の問題を解決することに尽力してきました。">
+    <meta property="og:site_name" content="AIライター協会">
+    <meta property="og:image" content="https://a-i-l-a.jp/assets/images/representative-director.png">
+    <meta name="twitter:card" content="summary_large_image">
+
+    <!-- Favicon -->
+    <link rel="icon" href="../assets/images/logo.png" type="image/png">
+    <link rel="apple-touch-icon" href="../assets/images/logo.png">
 
     <!-- Tailwind CSSを読み込み -->
     <script src="https://cdn.tailwindcss.com"></script>

--- a/members/member-template.html
+++ b/members/member-template.html
@@ -4,6 +4,20 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>会員名 - AIライター協会</title>
+    <meta name="description" content="MEMBER_DESCRIPTION_PLACEHOLDER">
+
+    <!-- OGP -->
+    <meta property="og:url" content="MEMBER_URL_PLACEHOLDER">
+    <meta property="og:type" content="profile">
+    <meta property="og:title" content="会員名 - AIライター協会">
+    <meta property="og:description" content="MEMBER_DESCRIPTION_PLACEHOLDER">
+    <meta property="og:site_name" content="AIライター協会">
+    <meta property="og:image" content="MEMBER_IMAGE_PLACEHOLDER">
+    <meta name="twitter:card" content="summary_large_image">
+
+    <!-- Favicon -->
+    <link rel="icon" href="../assets/images/logo.png" type="image/png">
+    <link rel="apple-touch-icon" href="../assets/images/logo.png">
     
     <!-- Tailwind CSSを読み込み -->
     <script src="https://cdn.tailwindcss.com"></script>

--- a/members/mizuma-yuki.html
+++ b/members/mizuma-yuki.html
@@ -4,6 +4,20 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>水間 雄紀 - AIライター協会</title>
+    <meta name="description" content="AIが文章を生成することが当たり前となった今、私たち人間に求められる役割は劇的に変化しました。AIが生み出した文章の真偽を見抜き、文脈を整え、読者の心に響く表現へと昇華させる「編集・推敲能力」こそが、これからのライターに不可欠なスキルであると、私たちは確信しています。">
+
+    <!-- OGP -->
+    <meta property="og:url" content="https://a-i-l-a.jp/members/mizuma-yuki.html">
+    <meta property="og:type" content="profile">
+    <meta property="og:title" content="水間 雄紀 - AIライター協会">
+    <meta property="og:description" content="AIが文章を生成することが当たり前となった今、私たち人間に求められる役割は劇的に変化しました。AIが生み出した文章の真偽を見抜き、文脈を整え、読者の心に響く表現へと昇華させる「編集・推敲能力」こそが、これからのライターに不可欠なスキルであると、私たちは確信しています。">
+    <meta property="og:site_name" content="AIライター協会">
+    <meta property="og:image" content="https://a-i-l-a.jp/assets/images/mizuma-yuki.png">
+    <meta name="twitter:card" content="summary_large_image">
+
+    <!-- Favicon -->
+    <link rel="icon" href="../assets/images/logo.png" type="image/png">
+    <link rel="apple-touch-icon" href="../assets/images/logo.png">
     
     <!-- Tailwind CSSを読み込み -->
     <script src="https://cdn.tailwindcss.com"></script>

--- a/members/oki-chinatsu.html
+++ b/members/oki-chinatsu.html
@@ -4,6 +4,20 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>大木 千夏 - AIライター協会</title>
+    <meta name="description" content="臨床検査技師として総合病院や大学発ベンチャーで経験を積んだ後、2021年にライターとして独立。医療・看護分野を中心に執筆する中で金融にも関心を持ち、2級FP技能士・AFPを取得。現在は独立系FP・金融ライターとしても活動中。">
+
+    <!-- OGP -->
+    <meta property="og:url" content="https://a-i-l-a.jp/members/oki-chinatsu.html">
+    <meta property="og:type" content="profile">
+    <meta property="og:title" content="大木 千夏 - AIライター協会">
+    <meta property="og:description" content="臨床検査技師として総合病院や大学発ベンチャーで経験を積んだ後、2021年にライターとして独立。医療・看護分野を中心に執筆する中で金融にも関心を持ち、2級FP技能士・AFPを取得。現在は独立系FP・金融ライターとしても活動中。">
+    <meta property="og:site_name" content="AIライター協会">
+    <meta property="og:image" content="https://a-i-l-a.jp/assets/images/oki-chinatsu.jpeg">
+    <meta name="twitter:card" content="summary_large_image">
+
+    <!-- Favicon -->
+    <link rel="icon" href="../assets/images/logo.png" type="image/png">
+    <link rel="apple-touch-icon" href="../assets/images/logo.png">
 
     <!-- Tailwind CSSを読み込み -->
     <script src="https://cdn.tailwindcss.com"></script>

--- a/membership.html
+++ b/membership.html
@@ -5,6 +5,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>入会案内 - AIライター協会</title>
     <meta name="description" content="AIライター協会の入会案内ページ。AI時代の最先端を走るライターコミュニティに参加しませんか？会員特典、入会条件、会費について詳しくご説明します。">
+
+    <!-- OGP -->
+    <meta property="og:url" content="https://a-i-l-a.jp/membership.html">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="入会案内 - AIライター協会">
+    <meta property="og:description" content="AIライター協会の入会案内ページ。AI時代の最先端を走るライターコミュニティに参加しませんか？会員特典、入会条件、会費について詳しくご説明します。">
+    <meta property="og:site_name" content="AIライター協会">
+    <meta property="og:image" content="https://a-i-l-a.jp/assets/images/logo.png">
+    <meta name="twitter:card" content="summary_large_image">
+
+    <!-- Favicon -->
+    <link rel="icon" href="/assets/images/logo.png" type="image/png">
+    <link rel="apple-touch-icon" href="/assets/images/logo.png">
     
     <!-- Tailwind CSSを読み込み -->
     <script src="https://cdn.tailwindcss.com"></script>

--- a/privacy.html
+++ b/privacy.html
@@ -5,6 +5,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>プライバシーポリシー - AIライター協会</title>
     <meta name="description" content="一般社団法人AIライター協会のプライバシーポリシーです。当協会が取得する個人情報の取り扱いに関する方針を定めています。">
+
+    <!-- OGP -->
+    <meta property="og:url" content="https://a-i-l-a.jp/privacy.html">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="プライバシーポリシー - AIライター協会">
+    <meta property="og:description" content="一般社団法人AIライター協会のプライバシーポリシーです。当協会が取得する個人情報の取り扱いに関する方針を定めています。">
+    <meta property="og:site_name" content="AIライター協会">
+    <meta property="og:image" content="https://a-i-l-a.jp/assets/images/logo.png">
+    <meta name="twitter:card" content="summary_large_image">
+
+    <!-- Favicon -->
+    <link rel="icon" href="/assets/images/logo.png" type="image/png">
+    <link rel="apple-touch-icon" href="/assets/images/logo.png">
     
     <!-- Tailwind CSSを読み込み -->
     <script src="https://cdn.tailwindcss.com"></script>

--- a/server.js
+++ b/server.js
@@ -71,9 +71,16 @@ app.post('/api/articles', upload.single('image'), async (req, res) => {
         const articleTemplate = await fs.readFile(articleTemplatePath, 'utf-8');
         const contentHtml = marked(content);
 
+        const articleUrl = `https://a-i-l-a.jp/articles/${newArticleFileName}`;
+        const imageUrl = `https://a-i-l-a.jp/assets/images/${imageFile.filename}`;
+
         const newArticleContent = articleTemplate
             .replace(/<title>.*<\/title>/, `<title>${title} - AIライター協会</title>`)
+            .replace(/<meta property="og:title" content=".*">/, `<meta property="og:title" content="${title} - AIライター協会">`)
             .replace(/<meta name="description" content=".*">/, `<meta name="description" content="${description}">`)
+            .replace(/<meta property="og:description" content=".*">/, `<meta property="og:description" content="${description}">`)
+            .replace('OG_URL_PLACEHOLDER', articleUrl)
+            .replace('OG_IMAGE_PLACEHOLDER', imageUrl)
             .replace(/<p class="text-gray-500 mb-2">.*<\/p>/, `<p class="text-gray-500 mb-2">${date}</p>`)
             .replace(/<h1 class="text-3xl md:text-4xl font-bold text-gray-900 leading-tight">.*<\/h1>/, `<h1 class="text-3xl md:text-4xl font-bold text-gray-900 leading-tight">${title}</h1>`)
             .replace(/<p class="text-sm mt-2 text-gray-500">.*<\/p>/, `<p class="text-sm mt-2 text-gray-500"><a href="../index.html" class="hover:underline">ホーム</a> &gt; <a href="../column.html" class="hover:underline">コラム</a> &gt; ${title}</p>`)


### PR DESCRIPTION
This commit introduces Open Graph (OGP) and favicon tags across the entire website to improve SEO and social media sharing appearance.

Key changes:
- Added OGP and favicon tags to all static HTML pages (`index.html`, `about.html`, etc.), with customized `og:title`, `og:description`, and `og:image` for each.
- Updated `article_templete.html` to include OGP tags with placeholders.
- Modified `server.js` to dynamically populate the OGP tags (including `og:url` and `og:image`) for newly created articles.
- Updated all existing member pages and the `members/member-template.html` with appropriate OGP tags.
- Set `logo.png` as the default favicon and `og:image`, while using more specific images for pages like the homepage and individual member/article pages where available.