### PR TITLE
Fix article list styling

### DIFF
--- a/articles/why-ai-generated-text-is-detectable.html
+++ b/articles/why-ai-generated-text-is-detectable.html
@@ -53,6 +53,22 @@
         .article-content a:hover {
             color: #1e3a8a; /* blue-800 */
         }
+        .article-content ul {
+            list-style-type: disc;
+            margin-left: 1.5rem;
+            margin-bottom: 1.5rem;
+            padding-left: 1rem;
+        }
+        .article-content li {
+            margin-bottom: 0.75rem;
+            line-height: 1.8;
+        }
+        .article-content ol {
+            list-style-type: decimal;
+            margin-left: 1.5rem;
+            margin-bottom: 1.5rem;
+            padding-left: 1rem;
+        }
     </style>
     <script src="../assets/js/main.js" defer></script>
 </head>


### PR DESCRIPTION
The lists in the articles were not styled, because of a CSS reset from Tailwind CSS.

This change adds CSS rules for `ul`, `ol`, and `li` elements within the `.article-content` class to ensure they are displayed correctly with proper indentation and bullet/numbering. The styles were added to the inline style block of the affected article to maintain consistency with the existing styling approach.