### PR TITLE
Fix: Update featured image for what-writers-should-do-to-avoid-ai-tak…

### DIFF
--- a/articles/what-writers-should-do-to-avoid-ai-takeover.html
+++ b/articles/what-writers-should-do-to-avoid-ai-takeover.html
@@ -83,7 +83,7 @@
                         <p class="text-gray-500 mb-2">2025.08.23</p>
                         <h1 class="text-3xl md:text-4xl font-bold text-gray-900 leading-tight">【2025年版】AIに仕事を奪われたくないライターの生存戦略｜AIを最強の相棒にする5つのステップ</h1>
                     </header>
-                    <img src="https://placehold.co/1200x600/5678A9/FFFFFF?text=AI+Survival+Strategy" alt="記事のメイン画像" class="w-full h-auto rounded-lg shadow-lg mb-12">
+                    <img src="../assets/images/what-writers-should-do-to-avoid-ai-takeover.png" alt="記事のメイン画像" class="w-full h-auto rounded-lg shadow-lg mb-12">
                     
                     <div class="article-content text-gray-800">
                         <p>生成AIの登場は、ライターという仕事に大きな変化をもたらしています。情報収集や構成案の作成、定型文の生成といった作業は、AIが瞬時にこなしてしまう時代になりました。その一方で、人間にしか書けない文章の価値が、これまで以上に強く求められています。</p>


### PR DESCRIPTION
…eover.html

The featured image for the article 'what-writers-should-do-to-avoid-ai-takeover.html' was using a placeholder URL. This commit updates the `src` attribute of the `<img>` tag to point to the correct local image file.